### PR TITLE
bugfix: expose port and add rocket env variable

### DIFF
--- a/_provisioning/an-api/Dockerfile
+++ b/_provisioning/an-api/Dockerfile
@@ -23,3 +23,5 @@ RUN wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/ma
 RUN git clone https://framagit.org/tricoteuses/tricoteuses-api-assemblee.git
 
 WORKDIR tricoteuses-api-assemblee
+
+EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,12 +53,16 @@ services:
   assemblee: 
     build:
       context: ./_provisioning/an-api
+    environment: 
+      - ROCKET_ENV=staging
     command: cargo run -p tricoteuses_api_assemblee -- -c Config.toml -v  
     volumes:  
       - ./_data:/assemblee-data/
     depends_on:
       - db
-    
+    ports: 
+      - 8000:8000
+
 volumes:
   pgdata:
   _dumps:


### PR DESCRIPTION
This should allow us to access webserver from outside the container by passing an environment variable to `rocket` in order to use the `staging` environment. 

This PR will only be merged if the following [PR](https://framagit.org/tricoteuses/tricoteuses-api-assemblee/merge_requests/2) gets merged also as it relies on the repo to have an docker compatible staging environment.