### PR TITLE
fix: replace old FROM with a functionnal build on the go of rust nightly

### DIFF
--- a/_provisioning/an-api/Dockerfile
+++ b/_provisioning/an-api/Dockerfile
@@ -1,8 +1,26 @@
-FROM rustlang/rust:nightly
+
+FROM buildpack-deps:stretch
 
 LABEL AUTHOR="Nelson Herbin <nelson@herbin.info>"
 LABEL NAME=tricoteuses-an-api
 LABEL VERSION=1
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN set -eux; \
+    \
+    url="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"; \
+    wget "$url"; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain nightly; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+    
 
 RUN apt-get update && \
 apt-get install -y unzip graphicsmagick

--- a/_provisioning/senat-api/Dockerfile
+++ b/_provisioning/senat-api/Dockerfile
@@ -1,7 +1,25 @@
-FROM rustlang/rust:nightly
+FROM buildpack-deps:stretch
 
 LABEL AUTHOR="Nelson Herbin <nelson@herbin.info>"
 LABEL NAME=tricoteuses-senat-api
+LABEL VERSION=1
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN set -eux; \
+    \
+    url="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"; \
+    wget "$url"; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain nightly; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+    
 LABEL VERSION=1
 
 RUN apt-get update && \

--- a/_provisioning/wikidata-api/Dockerfile
+++ b/_provisioning/wikidata-api/Dockerfile
@@ -1,9 +1,25 @@
-FROM rustlang/rust:nightly
+FROM buildpack-deps:stretch
 
 LABEL AUTHOR="Nelson Herbin <nelson@herbin.info>"
 LABEL NAME=tricoteuses-wikidata-api
 LABEL VERSION=1
 
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN set -eux; \
+    \
+    url="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"; \
+    wget "$url"; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain nightly; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+    
 RUN apt-get update && \
 apt-get install -y unzip 
 


### PR DESCRIPTION
nightly version provided on docker hub doesn't work anymore as it hasn't been updated. 

Some problems appeared with proc-macro2 which can't be fixed with non updated nightly version. 

This PR fixes the problem by building on the go the nightly version of rust. 